### PR TITLE
Add apt-transport-https package for MaaS test

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -57,6 +57,9 @@ if [ "${RE_JOB_SCENARIO}" = "functional" ]; then
   if [ "${TEST_RPC_MAAS}" != "False" ]; then
     pushd ${RPC_MAAS_DIR}
       export RE_JOB_SCENARIO="hummingbird"
+      ## This is needed for the maas job to be able to update the apt cache
+      ## When the influxdb repo is present.
+      apt-get install -y apt-transport-https
       bash tests/test-ansible-functional.sh
     popd
   fi


### PR DESCRIPTION
The image for the gate jobs has changed and nolonger includes the
apt-transport-https package by default. MaaS needs this in order to
update the apt cache when the influxdb repository is present.

This PR adds that package as part of testing.