### PR TITLE
HUM-904 We mark admins as "utility" for maas

### DIFF
--- a/docs/deploy/integration.md
+++ b/docs/deploy/integration.md
@@ -85,3 +85,9 @@ auth_address = http://10.2.2.15/v3
 key = your-password
 user = service:glance-swift
 ```
+
+## RPC MaaS
+
+The MaaS deploy will need to have the a utility group in the inventory to get openrc creds from.
+
+For the AIO, we generate openrc on the hummingbird admin boxes and set that as the utility group.

--- a/playbooks/group_vars/hummingbird.yml.sample
+++ b/playbooks/group_vars/hummingbird.yml.sample
@@ -33,3 +33,6 @@ filebeat_logstash_hosts:
 filebeat_logging_paths:
   - paths:
     - '/var/log/hummingbird/*.log'
+
+#MaaS
+maas_hummingbird_transactioncheck_enabled: true

--- a/tests/inventory_rpco
+++ b/tests/inventory_rpco
@@ -26,3 +26,5 @@ node03          service_ip=172.29.236.33
 
 [benchmark_hosts]
 
+[utility_all:children]
+hummingbird-admin

--- a/tests/test-vars.yml
+++ b/tests/test-vars.yml
@@ -84,3 +84,5 @@ maas_rpc_legacy_hummingbird: true
 #maas_hummingbird_accesscheck_password: accesspassword
 #maas_external_hostname: 172.29.236.31
 #external_lb_vip_address: 172.29.236.100
+# Enable the transaction check
+maas_hummingbird_transactioncheck_enabled: true


### PR DESCRIPTION
This allows maas to copy our openrc file from an aio admin box to the box
running the transaction check, which needs openrc creds.