### PR TITLE
RE-1698 Pin openstack-ansible-tests

### DIFF
--- a/ansible-role-test-requirements.yml
+++ b/ansible-role-test-requirements.yml
@@ -17,7 +17,7 @@
 - name: rpc-maas/tests/common
   src: https://git.openstack.org/openstack/openstack-ansible-tests
   scm: git
-  version: master
+  version: b146d649e675d748a58af238c7b37138b8194f1f
 - name: rsyslog_server
   src: https://git.openstack.org/openstack/openstack-ansible-rsyslog_server
   scm: git


### PR DESCRIPTION
This commit pins openstack-ansible-tests as a recent change made to that
repo is breaking rpc-hummingbird tests. The failure will need to be
investigated and we can revert this commit once the team knows what's
going on.