### PR TITLE
HUM-970 revert openstack-ansible-tests pin

### DIFF
--- a/ansible-role-test-requirements.yml
+++ b/ansible-role-test-requirements.yml
@@ -17,7 +17,7 @@
 - name: rpc-maas/tests/common
   src: https://git.openstack.org/openstack/openstack-ansible-tests
   scm: git
-  version: b146d649e675d748a58af238c7b37138b8194f1f
+  version: master
 - name: rsyslog_server
   src: https://git.openstack.org/openstack/openstack-ansible-rsyslog_server
   scm: git


### PR DESCRIPTION
This is to remind us to remove this pin once openstack-ansible-tests is fixed